### PR TITLE
Fix a memory leak when nopoll_conn_close_ext() is called, make sure t…

### DIFF
--- a/src/nopoll_conn.c
+++ b/src/nopoll_conn.c
@@ -1685,13 +1685,10 @@ void          nopoll_conn_close_ext  (noPollConn  * conn, int status, const char
 	refs = nopoll_conn_ref_count (conn);
 	nopoll_ctx_unregister_conn (conn->ctx, conn);
 
-	/* avoid calling next unref in the case not enough references
-	 * are found */
-	if (refs <= 1)
-		return;
-
 	/* call to unref connection */
-	nopoll_conn_unref (conn);
+	if (refs > 0) {
+            nopoll_conn_unref (conn);
+        }
 
 	return;	
 }


### PR DESCRIPTION
…o unreference all references.