### PR TITLE
API to open websocket with existing socket

### DIFF
--- a/src/libnopoll.def
+++ b/src/libnopoll.def
@@ -70,6 +70,7 @@ nopoll_conn_log_ssl
 nopoll_conn_mask_content
 nopoll_conn_new
 nopoll_conn_new6
+nopoll_conn_new_with_socket
 nopoll_conn_new_opts
 nopoll_conn_opts_free
 nopoll_conn_opts_new
@@ -113,6 +114,7 @@ nopoll_conn_sock_connect_opts
 nopoll_conn_socket
 nopoll_conn_tls_new
 nopoll_conn_tls_new6
+nopoll_conn_tls_new_with_socket
 nopoll_conn_tls_receive
 nopoll_conn_tls_send
 nopoll_conn_unref

--- a/src/nopoll_conn.h
+++ b/src/nopoll_conn.h
@@ -69,6 +69,16 @@ noPollConn * nopoll_conn_new_opts (noPollCtx       * ctx,
 				   const char      * protocols,
 				   const char      * origin);
 
+noPollConn * nopoll_conn_new_with_socket (noPollCtx  * ctx,
+			      noPollConnOpts  * opts,
+			      int          socket,
+			      const char * host_ip,
+			      const char * host_port,
+			      const char * host_name,
+			      const char * get_url,
+			      const char * protocols,
+			      const char * origin);
+
 noPollConn * nopoll_conn_tls_new (noPollCtx  * ctx,
 				  noPollConnOpts * options,
 				  const char * host_ip, 
@@ -86,6 +96,16 @@ noPollConn * nopoll_conn_tls_new6 (noPollCtx  * ctx,
 				   const char * get_url, 
 				   const char * protocols,
 				   const char * origin);
+
+noPollConn * nopoll_conn_tls_new_with_socket (noPollCtx  * ctx,
+				  noPollConnOpts * options,
+				  int          socket,
+				  const char * host_ip,
+				  const char * host_port,
+				  const char * host_name,
+				  const char * get_url,
+				  const char * protocols,
+				  const char * origin);
 
 noPollConn   * nopoll_conn_accept (noPollCtx * ctx, noPollConn * listener);
 


### PR DESCRIPTION
Add two functions, nopoll_conn_new_with_socket and
nopoll_conn_tls_new_with_socket, to open a websocket connection over an
already existing socket.