### PR TITLE
Build with mingw

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -413,6 +413,12 @@ if test x$enable_nopoll_doc = xyes ; then
 fi
 AM_CONDITIONAL(ENABLE_NOPOLL_DOC, test "x$DOXYGEN" = "xyes")
 
+case $host in
+  *-*-mingw*)
+    WS2_LIBS="-lws2_32"
+    AC_SUBST(WS2_LIBS)
+    ;;
+esac
 
 AC_OUTPUT([
 Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,7 +43,7 @@ libnopollinclude_HEADERS = \
 
 libnopoll_la_LDFLAGS = -no-undefined -export-symbols-regex '^(nopoll|__nopoll|_nopoll).*'
 
-libnopoll_la_LIBADD = $(TLS_LIBS)
+libnopoll_la_LIBADD = $(TLS_LIBS) $(WS2_LIBS)
 
 libnopoll.def: update-def
 

--- a/src/nopoll_decl.h
+++ b/src/nopoll_decl.h
@@ -168,13 +168,17 @@
 /* additional includes for the windows platform */
 
 /* _WIN32_WINNT note: If the application including the header defines
- * the _WIN32_WINNT, it must include the bit defined by the value
- * 0x400. */
+ * the _WIN32_WINNT, it must include the bits defined by the value
+ * 0x501. */
 #ifndef _WIN32_WINNT
-#  define _WIN32_WINNT 0x400
+#  define _WIN32_WINNT 0x501
+#elif _WIN32_WINNT < 0x501
+#  undef _WIN32_WINNT
+#  define _WIN32_WINNT 0x501
 #endif
 #include <winsock2.h>
 #include <windows.h>
+#include <ws2tcpip.h>
 #include <fcntl.h>
 #include <io.h>
 #include <process.h>


### PR DESCRIPTION
These patches are needed to build noPoll for Windows. Tested with MinGW64 5.3, both on Windows and cross-compiled from Fedora 23.