### PR TITLE
Fix handling pending write data

### DIFF
--- a/src/nopoll_private.h
+++ b/src/nopoll_private.h
@@ -308,6 +308,7 @@ struct _noPollConn {
 
 	char                * pending_write;
 	int                   pending_write_bytes;
+	int                   pending_write_desp;
 
 	/** 
 	 * @internal Internal reference to the connection options.


### PR DESCRIPTION
When SSL_write returns EAGAIN, it keeps a pointer to the data buffer
that was being written. This buffer must exist the next time that
SSL_write is called. So, this commit recycles the send_buffer in
nopoll_conn_send_frame as pending_write, instead of creating a new
buffer and copying so many data around.

Besides, nopoll_conn_send_frame correctly returns all the bytes as
written, since they are kept in the pending_write buffer. Otherwise,
the caller will try to write the same data again.