### PR TITLE
Fix WS PING/PONG implementation

### DIFF
--- a/src/nopoll_conn.h
+++ b/src/nopoll_conn.h
@@ -196,7 +196,7 @@ noPollConn  * nopoll_conn_get_listener (noPollConn * conn);
 
 nopoll_bool      nopoll_conn_send_ping (noPollConn * conn);
 
-nopoll_bool      nopoll_conn_send_pong (noPollConn * conn);
+nopoll_bool      nopoll_conn_send_pong (noPollConn * conn, long length, noPollPtr content);
 
 void          nopoll_conn_set_on_msg (noPollConn              * conn,
 				      noPollOnMessageHandler    on_msg,


### PR DESCRIPTION
WebSocket specification, section 5.5.3, states that 'A Pong frame sent
in response to a Ping frame must have identical "Application data" as
found in the message body of the Ping frame being replied to'. This
commit does that, instead of returning an empty Pong frame.