### PR TITLE
Test stack protector

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ compiler_options=""
 STRICT_PROTOTYPES=""
 echo "Detected compiler: $compiler"
 if test "$compiler" = "gcc" ; then
-   compiler_options="-Wstrict-prototypes -Wall -Werror -ansi -fstack-protector-all -Wstack-protector"
+   compiler_options="-Wstrict-prototypes -Wall -Werror -ansi"
    echo "Detected gcc compiler: $compiler, adding options: $compiler_options"
 fi
 AC_SUBST(compiler_options)
@@ -184,7 +184,16 @@ PTHREAD_LIBS="$nopoll_cv_pthreads_lib"
 AC_SUBST(PTHREAD_CFLAGS)
 AC_SUBST(PTHREAD_LIBS)
 
-
+my_save_cflags="$CFLAGS"
+CFLAGS="-fstack-protector-all -Wstack-protector"
+AC_MSG_CHECKING([whether CC supports -fstack-protector-all -Wstack-protector])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
+    [AC_MSG_RESULT([yes])]
+    [AM_CFLAGS="-fstack-protector-all -Wstack-protector"],
+    [AC_MSG_RESULT([no])]
+)
+CFLAGS="$my_save_cflags"
+AC_SUBST([AM_CFLAGS])
 
 AC_ARG_ENABLE(nopoll-log, [  --enable-nopoll-log     Enable building Nopoll with debug log support [default=yes]], enable_nopoll_log="$enableval", enable_nopoll_log=yes)
 AM_CONDITIONAL(ENABLE_NOPOLL_LOG, test "x$enable_nopoll_log" = "xyes")

--- a/src/nopoll_conn.c
+++ b/src/nopoll_conn.c
@@ -2968,7 +2968,7 @@ noPollMsg   * nopoll_conn_get_msg (noPollConn * conn)
 	int         bytes;
 	noPollMsg * msg;
 	int         ssl_error;
-	int         header_size;
+	int         header_size = 2;
 #if defined(SHOW_DEBUG_LOG)
 	long        result;
 #endif


### PR DESCRIPTION
For legacy reasons, I need to build and use the library on CentOS 4, as well as 5 and 6.

The version of GCC on CentOS 4 does not understand the stack-protector options, so this modification to `configure.ac` includes a test for whether those options are supported.

If `./autogen.sh` and `make dist` are done on a CentOS 6 system, the resulting `./configure` runs happily on CentOS 4 and correctly omits the stack protector options. They are of course still included properly on CentOS 5 and 6.

In addition, when building on CentOS 4, the compiler wrongly gives a warning that `header_size` might be used uninitialized in `nopoll_conn_get_msg()`. Adding an initialization suppresses that warning without changing the behaviour.