### PR TITLE
openssl 1.1: use EVP_MD_CTX as opaque type

### DIFF
--- a/src/nopoll_private.h
+++ b/src/nopoll_private.h
@@ -44,6 +44,7 @@
 #include <openssl/x509v3.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <openssl/opensslv.h>
 
 #include <nopoll_handlers.h>
 


### PR DESCRIPTION
openssl 1.1.0 made EVP_MD_CTX opaque, this change is required to have nopoll compile (e.g. on Debian 9 with openssl 1.1.0). Still, `-Werror` needs to be disabled as some functions are now declared deprecated.