### PR TITLE
Range check fds before using for FD_SET or FD_ISSET

### DIFF
--- a/src/nopoll_io.c
+++ b/src/nopoll_io.c
@@ -142,7 +142,7 @@ nopoll_bool  nopoll_io_wait_select_add_to (int               fds,
 {
 	noPollSelect * select = (noPollSelect *) __fd_set;
 
-	if (fds < 0) {
+	if (fds < 0 || fds >= FD_SETSIZE) {
 		nopoll_log (ctx, NOPOLL_LEVEL_CRITICAL,
 			    "received a non valid socket (%d), unable to add to the set", fds);
 		return nopoll_false;
@@ -183,6 +183,12 @@ nopoll_bool      nopoll_io_wait_select_is_set (noPollCtx   * ctx,
 {
 	noPollSelect * select = (noPollSelect *) __fd_set;
 	
+	if (fds < 0 || fds >= FD_SETSIZE) {
+		nopoll_log (ctx, NOPOLL_LEVEL_CRITICAL,
+			    "received a non valid socket (%d), unable to test in the set", fds);
+		return nopoll_false;
+	}
+
 	return FD_ISSET (fds, &(select->set));
 }
 


### PR DESCRIPTION
I had a crash associated with the closing of a websocket session from the remote end. I tracked it down to an out-of-range `fds` in `nopoll_io_wait_select_is_set()`. I think it might have been a race condition with shutting down the socket. Strange thing was that debugging the core dump with `gdb` showed `fds` contained `0x07FFFFFF` rather than `0xFFFFFFFF`.

But in any case, I think we need to check `fds` is not negative and not equal or higher than `FD_SETSIZE` before passing it to `FD_SET` or `FD_ISSET`, to avoid an array out-of-bounds access. Then such events will be handled gracefully.