### PR TITLE
Add support for ping with payload

### DIFF
--- a/src/nopoll_conn.c
+++ b/src/nopoll_conn.c
@@ -3561,6 +3561,15 @@ read_payload:
 		return NULL;
 	}
 
+	/* Received ping frame with payload */
+	if (msg->payload_size != 0 && msg->op_code == NOPOLL_PING_FRAME) {
+		nopoll_log (conn->ctx, NOPOLL_LEVEL_DEBUG, "PING received over connection id=%d with payload=%s and payload_size=%d , replying PONG", conn->id,msg->payload,msg->payload_size);
+
+		nopoll_conn_send_pong (conn, nopoll_msg_get_payload_size (msg), (noPollPtr)nopoll_msg_get_payload (msg));
+		nopoll_msg_unref (msg);
+		return NULL;
+	}
+
 	return msg;
 }
 


### PR DESCRIPTION
Ping with payload is not handled in Nopoll

As per https://tools.ietf.org/html/rfc6455#section-5.5.2 and https://tools.ietf.org/html/rfc6455#section-5.5.3, A ping frame may include payload/application data and the websocket library (nopoll) should respond with Pong frame with the same payload as the response. 
	
Currently in nopoll here https://github.com/ASPLes/nopoll/blob/master/src/nopoll_conn.c#L3448, Ping frame is handled only when the payload size is 0. 

This changes may support the above feature to respond pong frame with ping payload. 

Review these changes and Please, let me know if it has any review comments or requires any other changes/modification.