### PR TITLE
Add ping handler support for ping frame.

### DIFF
--- a/src/nopoll_conn.c
+++ b/src/nopoll_conn.c
@@ -3569,6 +3569,8 @@ read_payload:
 	if (msg->payload_size != 0 && msg->op_code == NOPOLL_PING_FRAME) {
 		nopoll_log (conn->ctx, NOPOLL_LEVEL_DEBUG, "PING received over connection id=%d and payload_size=%d, replying PONG",
 			    conn->id, msg->payload_size);
+		/* Set the ping handler */
+		conn->on_ping_msg (conn->ctx, conn, msg, conn->on_ping_msg_data);
 		nopoll_conn_send_pong (conn, nopoll_msg_get_payload_size (msg), (noPollPtr)nopoll_msg_get_payload (msg));
 		nopoll_msg_unref (msg);
 		return NULL;
@@ -4068,6 +4070,31 @@ void          nopoll_conn_set_on_msg (noPollConn              * conn,
 	/* configure on message handler */
 	conn->on_msg      = on_msg;
 	conn->on_msg_data = user_data;
+
+	return;
+}
+
+/**
+ * @brief Allows to configure an on ping message handler
+ * that will be called when ping with payload is received.
+ *
+ * @param conn The connection to be configured with a particular on ping message handler.
+ *
+ * @param on_ping_msg  The on ping message handler configured.
+ *
+ * @param user_data User defined pointer to be passed in into the on ping message handler when it is called.
+ *
+ */
+void          nopoll_conn_set_on_ping_msg (noPollConn              * conn,
+				      noPollOnMessageHandler    on_ping_msg,
+				      noPollPtr                 user_data)
+{
+	if (conn == NULL)
+		return;
+
+	/* configure on message handler */
+	conn->on_ping_msg      = on_ping_msg;
+	conn->on_ping_msg_data = user_data;
 
 	return;
 }

--- a/src/nopoll_conn.h
+++ b/src/nopoll_conn.h
@@ -110,6 +110,8 @@ noPollConn   * nopoll_conn_accept (noPollCtx * ctx, noPollConn * listener);
 
 noPollConn   * nopoll_conn_accept_socket (noPollCtx * ctx, noPollConn * listener, NOPOLL_SOCKET session);
 
+void nopoll_conn_set_on_ping_msg (noPollConn * conn, noPollOnMessageHandler on_ping_msg, noPollPtr user_data);
+
 nopoll_bool    nopoll_conn_accept_complete (noPollCtx      * ctx, 
 					    noPollConn     * listener, 
 					    noPollConn     * conn, 

--- a/src/nopoll_private.h
+++ b/src/nopoll_private.h
@@ -233,6 +233,12 @@ struct _noPollConn {
 	noPollOnMessageHandler on_msg;
 	noPollPtr              on_msg_data;
 
+	/**
+	 * @internal Reference to the defined on ping message handling.
+	 */
+	noPollOnMessageHandler on_ping_msg;
+    noPollPtr              on_ping_msg_data;
+
 	/** 
 	 * @internal Reference to defined on ready handling.
 	 */


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc6455#section-5.5.2 definition, A Ping frame MAY include "Application data".

In nopoll when PING frame is recieved with payload, it responds with PONG frame having same payload. In case if the user/client is interested in the payload/application data it received with PING, then there is no option for the client to get that payload.

If we have ping handler similar to msg handler then it will be useful/easier for the client to get that payload. And based on the ping handler, client can set the timer in their application to detect any timeout or pings not received over the connection for certain amount of time due to some network issue, then client can close the connection completely and retry again with new server.

Review these changes and Please let me know if it requires any modification/suggestion from your end.