### PR TITLE
Add changes to support URL redirection.

### DIFF
--- a/src/nopoll_conn.h
+++ b/src/nopoll_conn.h
@@ -225,6 +225,9 @@ int           __nopoll_conn_send_common (noPollConn * conn,
 nopoll_bool      nopoll_conn_wait_until_connection_ready (noPollConn * conn,
 							  int          timeout);
 
+nopoll_bool      nopoll_conn_wait_for_status_until_connection_ready (noPollConn * conn,
+							  int          timeout, int *status, char **message);
+
 void               nopoll_conn_connect_timeout (noPollCtx * ctx,
 						long        microseconds_to_wait);
 

--- a/src/nopoll_private.h
+++ b/src/nopoll_private.h
@@ -372,6 +372,8 @@ struct _noPollHandshake {
 	nopoll_bool     upgrade_websocket;
 	nopoll_bool     connection_upgrade;
 	nopoll_bool     received_101; 
+	nopoll_bool     received_non_101;
+	int             httpStatus;
 	char          * websocket_key;
 	char          * websocket_version;
 	char          * websocket_accept;
@@ -379,6 +381,8 @@ struct _noPollHandshake {
 
 	/* reference to cookie header */
 	char          * cookie;
+	/* redirect Location URL */
+	char * redirectURL;
 };
 
 struct _noPollConnOpts {


### PR DESCRIPTION
Server URL redirection is not handled in nopoll.

As per RFC https://tools.ietf.org/html/rfc6455#section-4.2.2, library/server should handle non 101 status code received during handshake. Currently nopoll is not handling this feature, whenever it receives non 101 status code will close the connection and not supporting any other functionality like URL redirection in case of 3xx status code is received.
 
These changes may handle this scenario, if server sends redirection URL to the user/client using a 3xx status code, the user/client may establish connection with the redirected URL. 
 
Review these changes and Please let me know if it requires any modification/suggestion from your end.