### PR TITLE
fix connect error log to report the correct errno

### DIFF
--- a/src/nopoll_conn.c
+++ b/src/nopoll_conn.c
@@ -300,11 +300,11 @@ NOPOLL_SOCKET __nopoll_conn_sock_connect_opts_internal (noPollCtx       * ctx,
 	/* do a tcp connect */
         if (connect (session, res->ai_addr, res->ai_addrlen) < 0) {
 		if(errno != NOPOLL_EINPROGRESS && errno != NOPOLL_EWOULDBLOCK && errno != NOPOLL_ENOTCONN) { 
-		        shutdown (session, SHUT_RDWR);
-                        nopoll_close_socket (session);
-
 			nopoll_log (ctx, NOPOLL_LEVEL_WARNING, "unable to connect to remote host %s:%s errno=%d",
 				    host, port, errno);
+
+		        shutdown (session, SHUT_RDWR);
+                        nopoll_close_socket (session);
 
 			/* relase address info */
 			freeaddrinfo (res);


### PR DESCRIPTION
In function __nopoll_conn_sock_connect_opts_internal, after a connect failure, the log statement is currently placed after the socket shutdown and close, so that errno may by changed before the message is printed.

This change moves the log statement to before the socket shutdown and close, so that errno is reported correctly. 