### PR TITLE
fix documentation generation with doxygen-1.8.16

### DIFF
--- a/doc/nopoll.doxygen.in
+++ b/doc/nopoll.doxygen.in
@@ -679,7 +679,7 @@ INPUT_ENCODING         = UTF-8
 # *.hxx *.hpp *.h++ *.idl *.odl *.cs *.php *.php3 *.inc *.m *.mm *.dox *.py
 # *.f90 *.f *.for *.vhd *.vhdl
 
-FILE_PATTERNS          =
+#FILE_PATTERNS          =
 
 # The RECURSIVE tag can be used to turn specify whether or not subdirectories
 # should be searched for input files as well. Possible values are YES and NO.


### PR DESCRIPTION
This gets around a known bug in doxygen-1.8.16 (see issue 7190).
Doxygen-1.8.16 generates no documentation whenever FILE_PATTERNS
is set to empty, without printing any warnings or errors.