### PR TITLE
Fix race condition between ssl handshake and loop event

### DIFF
--- a/src/nopoll_loop.c
+++ b/src/nopoll_loop.c
@@ -62,6 +62,10 @@ nopoll_bool nopoll_loop_register (noPollCtx * ctx, noPollConn * conn, noPollPtr 
 		return nopoll_false; /* keep foreach, don't stop */
 	}
 
+        /* Do not listen on sockets that are doing SSL/TLS handshake */
+        if (conn->pending_ssl_connect)
+                return nopoll_false;
+
 	/* register the connection socket */
 	/* nopoll_log (ctx, NOPOLL_LEVEL_DEBUG, "Adding socket id: %d", conn->session);*/
 	if (! ctx->io_engine->add_to (conn->session, ctx, conn, ctx->io_engine->io_object)) {

--- a/src/nopoll_private.h
+++ b/src/nopoll_private.h
@@ -274,6 +274,13 @@ struct _noPollConn {
 	 */
 	nopoll_bool   pending_ssl_accept;
 
+        /**
+         * @internal Flag that indicates that the provided session
+         * is in the process of doing a TLS handshake and must not
+         * be read or written to by any other function than SSL_Connect()
+         */
+        nopoll_bool   pending_ssl_connect;
+
 	/* SSL support */
 	SSL_CTX        * ssl_ctx;
 	SSL            * ssl;


### PR DESCRIPTION
When connecting to an SSL/TLS site and at the same time using the nopoll_loop_wait() event loop there is a race condition between the event loop waking up and reading from the socket and the SSL_Connect() loop. If the event loop reads the socket first, before SSL_Connect() is done with the ssl handshake the ssl handshake to fails.

This patch is an attempt at fixing that race condition by introducing a check so that the event loop is not listening on ssl sockets before the ssl handshake is done. 